### PR TITLE
Update documentation links to v4

### DIFF
--- a/DeleteImageTask/task.json
+++ b/DeleteImageTask/task.json
@@ -3,7 +3,7 @@
     "name": "RedgateSqlCloneDeleteImage",
     "friendlyName": "SQL Clone - Delete image",
     "description": "Delete images created by SQL Clone",
-    "helpMarkDown": "[More Information](https://documentation.red-gate.com/clone3)",
+    "helpMarkDown": "[More Information](https://documentation.red-gate.com/clone4)",
     "category": "Build",
     "visibility": [
         "Build", "Release"

--- a/DeleteTask/task.json
+++ b/DeleteTask/task.json
@@ -3,7 +3,7 @@
     "name": "RedgateSqlCloneDelete",
     "friendlyName": "SQL Clone - Delete clone",
     "description": "Delete clones created by SQL Clone",
-    "helpMarkDown": "[More Information](https://documentation.red-gate.com/clone3)",
+    "helpMarkDown": "[More Information](https://documentation.red-gate.com/clone4)",
     "category": "Build",
     "visibility": [
         "Build", "Release"

--- a/ImageTask/task.json
+++ b/ImageTask/task.json
@@ -3,7 +3,7 @@
     "name": "RedgateSqlCloneImage",
     "friendlyName": "SQL Clone - Create image",
     "description": "Create images with SQL Clone",
-    "helpMarkDown": "[More Information](https://documentation.red-gate.com/clone3)",
+    "helpMarkDown": "[More Information](https://documentation.red-gate.com/clone4)",
     "category": "Build",
     "visibility": [
         "Build",

--- a/extension-manifest.json
+++ b/extension-manifest.json
@@ -66,7 +66,7 @@
         "home":          { "uri": "http://www.red-gate.com/products/dba/sql-clone" },
         "learn":         { "uri": "https://www.red-gate.com/products/dba/sql-clone/resources" },
         "support":       { "uri": "https://www.red-gate.com/products/dba/sql-clone/support" },
-        "release notes": { "uri": "https://documentation.red-gate.com/clone3/release-notes-and-other-versions" }
+        "release notes": { "uri": "https://documentation.red-gate.com/clone4/release-notes-and-other-versions" }
     },
     "branding": {
         "color": "white",


### PR DESCRIPTION
The documentation links still went to v3. Updating them to go to v4.

**Risks and mitigations**
* The link might be incorrect
  * [x] Manually confirmed that the link is correct